### PR TITLE
fix setting localstorage before navigation in blur handler

### DIFF
--- a/cypress/integration/app_spec.js
+++ b/cypress/integration/app_spec.js
@@ -48,6 +48,7 @@ describe('TodoMVC - React', function () {
     // Since todos are updated on blur after editing,
     // this is needed to blur activeElement after each test to prevent state leakage between tests.
     cy.window().then((win) => {
+      // @ts-ignore
       win.document.activeElement.blur()
     })
   })

--- a/cypress/integration/app_spec.js
+++ b/cypress/integration/app_spec.js
@@ -44,6 +44,9 @@ describe('TodoMVC - React', function () {
   })
 
   afterEach(() => {
+    // In firefox, blur handlers will fire upon navigation if there is an activeElement.
+    // Since todos are updated on blur after editing,
+    // this is needed to blur activeElement after each test to prevent state leakage between tests.
     cy.window().then((win) => {
       win.document.activeElement.blur()
     })

--- a/cypress/integration/app_spec.js
+++ b/cypress/integration/app_spec.js
@@ -43,6 +43,12 @@ describe('TodoMVC - React', function () {
     cy.visit('/')
   })
 
+  afterEach(() => {
+    cy.window().then((win) => {
+      win.document.activeElement.blur()
+    })
+  })
+
   // a very simple example helpful during presentations
   it('adds 2 todos', function () {
     cy.get('.new-todo')


### PR DESCRIPTION
in firefox, blur handlers will fire upon navigation if there is an activeElement.

Since todos are updated on blur after editing, an `afterEach` is needed to blur activeElement after each test to prevent state leakage between tests