### PR TITLE
Upgrade circle xcode version to 13.0.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ executors:
       - image: cypress/base:12
   mac:
     macos:
-      xcode: "10.1.0"
+      xcode: "13.0.0"
 
 jobs:
   lint:


### PR DESCRIPTION
Current version (10.1.0) was removed on September 14, 2021 and causes failures like [this one](https://app.circleci.com/pipelines/github/cypress-io/cypress-example-todomvc/513/workflows/90202a35-6a77-4a1a-8097-c9880eb15af7/jobs/1914).
