### PR TITLE
fix: Fixes to examples in preparation for Cy 12

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -52,6 +52,10 @@ Cypress.Commands.add('createDefaultTodos', function () {
     // 'spinning blue state' to the 'finished state'
     cmd.set({ $el: $listItems }).snapshot().end()
   })
+
+  // return a query for the todo items so that we can
+  // alias the result of this command in our tests
+  return cy.get('.todo-list li', { log: false })
 })
 
 Cypress.Commands.add('createTodo', function (todo) {
@@ -81,6 +85,11 @@ Cypress.Commands.add('createTodo', function (todo) {
     // our command
     cmd.set({ $el: $li }).snapshot().end()
   })
+
+  // return a query for the todo items so that we can
+  // alias the result of this command in our tests
+  return cy.get('.todo-list', { log: false })
+  .contains('li', todo.trim(), { log: false })
 })
 
 Cypress.Commands.add('addAxeCode', () => {


### PR DESCRIPTION
Cypress 12 contains breaking changes around how aliases retry commands, leading to new recommended patterns. While unfortunate, this repo demonstrates the sorts of problems users will run into, and why we recommend the new pattern.

The two custom commands in here return the results of `cy.get().then()` - and when React updates the page, Cy 12 knows it's unsafe to rerun `.then()`, leading to detached DOM errors.

This PR updates the example repo to match our recommendations, which is that when interacting with the DOM, you alias chains of queries, and not the results of commands, so that Cy knows how to retry them properly when the DOM updates. This update will work in all versions of cypress, so is safe to merge immediately, and does not need to wait for Cypress 12 to go out.