### PR TITLE
ci: update Node.js in appveyor to 18

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 # https://www.appveyor.com/docs/lang/nodejs-iojs/
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "12"
+  nodejs_version: "18"
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
This PR updates AppVeyor to use Node.js 18 instead of Node.js 12.

According to the [Node.js release schedule](https://github.com/nodejs/release#release-schedule) Node.js 12 entered End-of-Life on Apr 30, 2022. Node.js 18 is the current LTS version.