### PR TITLE
chore: update xcode and resource class to gen2 macOS executor

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,8 @@ executors:
       - image: cypress/base:18.16.1
   mac:
     macos:
-      xcode: "14.0.1"
+      xcode: "14.3.1"
+    resource_class: macos.x86.medium.gen2
 
 jobs:
   lint:


### PR DESCRIPTION
update circleCI macOS runner to gen2 as gen1 is being removed on Octobor 2nd