### PR TITLE
ci(deps): update GHA actions to latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run E2E tests
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           start: npm run start
           wait-on: http://localhost:8888


### PR DESCRIPTION
## Issue

[.github/workflows/main.yml](https://github.com/cypress-io/cypress-example-todomvc/blob/master/.github/workflows/main.yml) uses outdated versions:

- `actions/checkout@v3`
- `cypress-io/github-action@v5`

which causes deprecations warnings in the [actions workflow logs](https://github.com/cypress-io/cypress-example-todomvc/actions/workflows/main.yml)

> cypress-run
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, cypress-io/github-action@v5. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

## Change

Update [.github/workflows/main.yml](https://github.com/cypress-io/cypress-example-todomvc/blob/master/.github/workflows/main.yml) to use current versions:

- [actions/checkout@v4](https://github.com/actions/checkout)
- [cypress-io/github-action@v6](https://github.com/cypress-io/github-action)
