### PR TITLE
ci(deps): update CircleCI Cypress Orb to v3

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@
 
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@1
+  cypress: cypress-io/cypress@3
   # for testing on Windows
   win: circleci/windows@5
 


### PR DESCRIPTION
## Issue

[circle.yml](https://github.com/cypress-io/cypress-example-todomvc/blob/master/circle.yml) uses an outdated version:

- `cypress: cypress-io/cypress@1`

The repo is configured in the following to use Cypress `13.x`

https://github.com/cypress-io/cypress-example-todomvc/blob/e091b3de66594434ac67c95d1d2d7d0916dba717/package.json#L43

A minimum of [Cypress Orb v2](https://github.com/cypress-io/circleci-orb/releases/tag/v2.0.0) is however needed for Cypress v10 (and higher) compatibility.

## Change

Update [circle.yml](https://github.com/cypress-io/cypress-example-todomvc/blob/master/circle.yml) to use the current version v3 of the [CircleCI Cypress Orb](https://circleci.com/developer/orbs/orb/cypress-io/cypress):

- `cypress: cypress-io/cypress@3`